### PR TITLE
Update scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
 	"scripts": {
 		"dev": "vite dev --port 3000",
 		"build": "vite build",
-		"package": "svelte-kit package",
-		"preview": "svelte-kit preview",
+		"preview": "vite preview",
 		"test": "playwright test",
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",


### PR DESCRIPTION

1. Update preview command based on error
    ```
    > svelte-kit preview is no longer available — use vite preview instead
    ```

1. Remove svelte-kit package based on error and presence of `vite.config.js`
    ```
    $ svelte-kit package
    svelte-kit package has been removed. It now lives in its own npm package. See the PR on how to migrate: https://github.com/sveltejs/kit/pull/5730
    ```
